### PR TITLE
Add-more-fields-to-XCom-View

### DIFF
--- a/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow/ui/src/pages/XCom/XCom.tsx
@@ -16,15 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
+import { Box, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { useXcomServiceGetXcomEntries } from "openapi/queries";
 import type { XComResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { TruncatedText } from "src/components/TruncatedText";
+import { getTaskInstanceLinkFromObj } from "src/utils/links";
 
 import { XComEntry } from "./XComEntry";
 
@@ -33,6 +35,49 @@ const columns: Array<ColumnDef<XComResponse>> = [
     accessorKey: "key",
     enableSorting: false,
     header: "Key",
+  },
+  {
+    accessorKey: "dag_id",
+    cell: ({ row: { original } }) => (
+      <Link asChild color="fg.info" fontWeight="bold">
+        <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_id}</RouterLink>
+      </Link>
+    ),
+    header: "Dag",
+  },
+  {
+    accessorKey: "run_id",
+    cell: ({ row: { original } }: { row: { original: XComResponse } }) => (
+      <Link asChild color="fg.info" fontWeight="bold">
+        <RouterLink to={`/dags/${original.dag_id}/runs/${original.run_id}`}>
+          <TruncatedText text={original.run_id} />
+        </RouterLink>
+      </Link>
+    ),
+    header: "Run Id",
+  },
+  {
+    accessorKey: "task_id",
+    cell: ({ row: { original } }: { row: { original: XComResponse } }) => (
+      <Link asChild color="fg.info" fontWeight="bold">
+        <RouterLink
+          to={getTaskInstanceLinkFromObj({
+            dagId: original.dag_id,
+            dagRunId: original.run_id,
+            mapIndex: original.map_index,
+            taskId: original.task_id,
+          })}
+        >
+          <TruncatedText text={original.task_id} />
+        </RouterLink>
+      </Link>
+    ),
+    enableSorting: false,
+    header: "Task ID",
+  },
+  {
+    accessorKey: "map_index",
+    header: "Map Index",
   },
   {
     cell: ({ row: { original } }) => (

--- a/airflow/ui/src/utils/links.ts
+++ b/airflow/ui/src/utils/links.ts
@@ -1,22 +1,41 @@
 /*!
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
-export const getTaskInstanceLink = (ti: TaskInstanceResponse) =>
-  `/dags/${ti.dag_id}/runs/${ti.dag_run_id}/tasks/${ti.task_id}${ti.map_index >= 0 ? `/mapped/${ti.map_index}` : ""}`;
+// Function to handle a flexible object with additional fields
+export const getTaskInstanceLink = (ti: Record<string, unknown> & TaskInstanceResponse) =>
+ `/dags/${ti.dag_id}/runs/${ti.dag_run_id}/tasks/${ti.task_id}${ti.map_index >= 0 ? `/mapped/${ti.map_index}` : ""}`;
+
+
+// New function with object destructuring for flexibility and future fields
+export const getTaskInstanceLinkFromObj = ({
+ dagId,
+ dagRunId,
+ mapIndex = -1,
+ taskId,
+ ...rest // Allows for future fields
+}: {
+ [key: string]: unknown; // Allows for new fields to be added in the future
+ dagId: string;
+ dagRunId: string;
+ mapIndex?: number;
+ taskId: string;
+}) => `/dags/${dagId}/runs/${dagRunId}/tasks/${taskId}${mapIndex >= 0 ? `/mapped/${mapIndex}` : ""}`;


### PR DESCRIPTION
### AP-121-Add-more-fields-to-XCom-View

**Description of the Issue**
This issue highlights a limitation in the current XCom view of Apache Airflow. XCom (short for "cross-communication") is used for passing small amounts of data between tasks in a DAG (Directed Acyclic Graph). However, the existing XCom view does not display certain key fields such as:
dag_id (identifies the DAG associated with the XCom entry)
run_id (identifies the specific DAG run)
task_id (identifies the task that generated the XCom entry)
Without these fields, it is difficult to track the origin of an XCom entry and associate it with a specific DAG run or task. Users may struggle to analyze and debug XCom data effectively.

**The detailed description can be found in the attached document below:-**
https://docs.google.com/document/d/19ak07i8dudsQWBOGzS15oH0ScGfv1gjHBZMohuG1AW4/edit?tab=t.0#heading=h.41jopxa4gac

![image](https://github.com/user-attachments/assets/80bc18d3-b8bc-4eef-b465-47f83de8411d)
